### PR TITLE
issue-2 Updated the select_dtypes(include='object') call to use a lis…

### DIFF
--- a/app/pandas_workshop.ipynb
+++ b/app/pandas_workshop.ipynb
@@ -8274,7 +8274,7 @@
     "#I can do a heatmap on non object data types.\n",
     "\n",
     "\n",
-    "obj_cols=set(housing.select_dtypes(include='object').columns)\n",
+    "obj_cols=set(housing.select_dtypes(include=['object']).columns)\n",
     "heatmap_cols=[col for col in list(housing.columns) if col not in obj_cols]\n",
     "#set(untouched_cols).intersection(obj_cols)  #empty\n",
     "#len(set(cols_to_impute).intersection(obj_cols)) \n",


### PR DESCRIPTION
…t instead so that the notebook functions correctly in Azure Notebooks.